### PR TITLE
feat: add short_description for storefront tagline

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -3,6 +3,7 @@ name: Observer
 slug: observer
 version: 2.0.0
 description: User truth capture skills for hypothesis-first research
+short_description: "Hypothesis-first user research"
 domain:
   - analytics
 author: 0xHoneyJar


### PR DESCRIPTION
Add `short_description` field to `construct.yaml` for constructs.network catalog display.

Tagline: **Hypothesis-first user research**

Part of 0xHoneyJar/loa-constructs#157

🤖 Generated with [Claude Code](https://claude.com/claude-code)