### PR TITLE
feat: composition metadata — paths, relationships

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -87,6 +87,17 @@ events:
         issue_url: string
   consumes:
     - event: forge.crucible.journey_validated
+type: skill-pack
+composition_paths:
+  writes:
+    - grimoires/laboratory/canvases/
+    - grimoires/laboratory/journeys/
+    - grimoires/laboratory/synthesis/
+compose_with:
+  - slug: crucible
+    relationship: "Circular validation — Observer captures user truth, Crucible validates journeys, Observer consumes validation results"
+  - slug: artisan
+    relationship: "Canonical pairing — Observer canvases provide user truth that informs Artisan's taste decisions"
 pack_dependencies:
   - slug: crucible
   - slug: artisan


### PR DESCRIPTION
## Why

The network now surfaces grimoire path connections in the explorer graph. This PR declares paths and composition relationships that Observer already uses — no behavioral change, just metadata.

## Changes

- **`composition_paths.writes`**: `grimoires/laboratory/canvases/`, `grimoires/laboratory/journeys/`, `grimoires/laboratory/synthesis/`
- **`compose_with`**: crucible (circular validation loop), artisan (canonical pairing — canvases inform taste)
- **`type: skill-pack`**: Was missing from manifest

## Part of

Cycle-051 network-wide composition metadata fan-out (hub constructs batch).